### PR TITLE
fix: grammar in main.zig

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -39,7 +39,7 @@ pub fn main() !void {
         std.debug.print("Config read successfully!\n", .{});
     } else |err| {
         if (err == std.fs.File.OpenError.FileNotFound) {
-            const token = terminal.promptUser(allocator, "No configuration file not found, please enter your Moodle token!\n") catch |e| {
+            const token = terminal.promptUser(allocator, "No configuration file found, please enter your Moodle token!\n") catch |e| {
                 std.debug.print("Error occured: {!}\n", .{e});
                 return;
             };


### PR DESCRIPTION
Very nice project 👍 
This pull request includes a small but important change to the user prompt message in the `main` function of the `src/main.zig` file. The change corrects a grammatical error in the message displayed when no configuration file is found.

* [`src/main.zig`](diffhunk://#diff-d924ca21d81d7d5a59eb9e10d3e2689c4c58a7e28e6ecce6a064701666f5a730L42-R42): Corrected the prompt message to remove the duplicate "not" in the sentence "No configuration file not found, please enter your Moodle token!"